### PR TITLE
Issue #6: Frequent git status check when typing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -100,16 +100,8 @@ if (isDevelopment) {
       }
     }, 1000)
 
-    logseq.App.onRouteChanged(async () => {
-      checkStatus()
-    })
-    logseq.DB.onChanged(async () => {
-      setTimeout(() => {
-        checkStatus()
-      }, 1000)
-    })
-
-
+    logseq.App.onRouteChanged(debounce(async () => { checkStatus() }))
+    logseq.DB.onChanged(debounce(async () => { checkStatus() }, 1000))
   })
 }
 


### PR DESCRIPTION
Each keystroke schedules a git status check without debouncing, causing
a pile-up of tasks and ensuing slowdown.

Debounce these tasks.