### PR TITLE
Added Custom Commit Message

### DIFF
--- a/src/helper/constants.ts
+++ b/src/helper/constants.ts
@@ -143,4 +143,20 @@ export const SETTINGS_SCHEMA: SettingSchemaDesc[] = [
     default: false,
     description: "Auto push when logseq hide",
   },
+  {
+    key: "typeCommitMessage",
+    title: "Type Commit Message",
+    type: "enum",
+    default: "Default Message With Date",
+    description: "Type of commit message to use",
+    enumPicker: "select",
+    enumChoices: ['Custom Message' , 'Default Message', 'Custom Message With Date', 'Default Message With Date'],
+  },
+  {
+    key: "customCommitMessage",
+    title: "Custom Commit Message",
+    type: "string",
+    default: "",
+    description: "Custom commit message for plugin (valid only if commit message is set to Custom Message)",
+  }
 ];

--- a/src/helper/git.ts
+++ b/src/helper/git.ts
@@ -140,3 +140,36 @@ export const push = async (showRes = true): Promise<IGitResult> => {
   }
   return res
 }
+
+
+/**
+ * Returns the commit message based on the selected commit message type in the logseq settings.
+ * @returns The commit message.
+ */
+export const commitMessage = () : string => {
+  
+  let defaultMessage = "[logseq-plugin-git:commit]";
+
+  switch (logseq.settings?.typeCommitMessage as string) {
+    case "Default Message":
+      return defaultMessage;
+    case "Default Message With Date":
+      return defaultMessage + " " + new Date().toISOString();
+    case "Custom Message":
+      let customMessage = logseq.settings?.customCommitMessage as string;
+      if (customMessage.trim() === "") {
+        return defaultMessage;
+      } else {
+        return customMessage;
+      }
+    case "Custom Message With Date":
+      let customMessageWithDate = logseq.settings?.customCommitMessage as string;
+      if (customMessageWithDate.trim() === "") {
+        return defaultMessage + " " + new Date().toISOString();
+      } else {
+        return customMessageWithDate + " " + new Date().toISOString();
+      }
+    default:
+      return defaultMessage;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { BUTTONS, LOADING_STYLE, SETTINGS_SCHEMA } from "./helper/constants";
 import {
   checkout,
   commit,
+  commitMessage,
   log,
   pull,
   pullRebase,
@@ -77,7 +78,7 @@ if (isDevelopment) {
       }),
       commit: debounce(async function () {
         hidePopup();
-        commit(true, `[logseq-plugin-git:commit] ${new Date().toISOString()}`);
+        commit(true, commitMessage());
       }),
       push: debounce(async function () {
         setPluginStyle(LOADING_STYLE);
@@ -94,7 +95,7 @@ if (isDevelopment) {
         if (changed) {
           const res = await commit(
               true,
-              `[logseq-plugin-git:commit] ${new Date().toISOString()}`
+              commitMessage()
           );
           if (res.exitCode === 0) await push(true);
         }


### PR DESCRIPTION
I have added the feature for users to insert a custom message within their Git commit. 

I started by adding two settings: a select field with four options - ‘Custom Message’, ‘Default Message’, ‘Custom Message With Date’, and ‘Default Message With Date’, and a text field in where users can personalize their commit messages.

Explaination now for the settings:
- The default setting is ‘Default Message With Date’, which leaves the behavior of the plugin unchanged.
- ‘Default Message’ option, I have simply removed the date indication. 
- ‘Custom Message’ option, simply the function takes the text in the text field added. I have implemented appropriate checks to ensure that if the field is left empty, the default message with the date is sent, thus not altering the original behavior.
- ‘Custom Message With Date’ option functions the same as the ‘Custom Message’ option but adds the date indication. 

This enhancement provides users with more flexibility and personalization in their Git commit messages.