### PR TITLE
Add Commit & Pull Rebase & Push action for convenient all-in-one update

### DIFF
--- a/src/helper/constants.ts
+++ b/src/helper/constants.ts
@@ -109,6 +109,7 @@ export const BUTTONS = [
   { key: "commit", title: "Commit", event: "commit" },
   { key: "push", title: "Push", event: "push" },
   { key: "commitAndPush", title: "Commit & Push", event: "commitAndPush" },
+  { key: "commitAndPullRebaseAndPush", title: "Commit & Pull Rebase & Push", event: "commitAndPullRebaseAndPush" },
 ];
 
 export const SETTINGS_SCHEMA: SettingSchemaDesc[] = [

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -102,6 +102,26 @@ if (isDevelopment) {
         }
         checkStatus();
       }),
+      commitAndPullRebaseAndPush: debounce(async function () {
+        setPluginStyle(LOADING_STYLE);
+        hidePopup();
+
+        const status = await checkStatus();
+        const changed = status?.stdout !== "";
+        if (changed) {
+          const res = await commit(
+              true,
+              commitMessage()
+          );
+
+          if (res.exitCode === 0) {
+            const pull_res = await pullRebase();
+            if (pull_res.exitCode == 0) await push(true);
+          }
+        }
+        checkStatus();
+      }),
+
       log: debounce(async function () {
         console.log("[faiz:] === log click");
         const res = await log(false);
@@ -215,6 +235,17 @@ if (isDevelopment) {
         },
       },
       () => operations.commitAndPush()
+    );
+    logseq.App.registerCommandPalette(
+      {
+        key: "logseq-plugin-git:commit&pullrebase&push",
+        label: "Commit & Pull Rebase & Push",
+        keybinding: {
+          binding: "unset",
+          mode: "global",
+        },
+      },
+      () => operations.commitAndPullRebaseAndPush()
     );
     logseq.App.registerCommandPalette(
         {


### PR DESCRIPTION
Using this plugin to use logseq collaboratively and want the experience to be as seamless as possible. This allows to add a keybind that works even if upstream has new commit, with the old "Commit & Push" and "Pull Rebase" buttons I found myself often doing "Commit & Push" -> fail -> "Pull Rebase" -> "Commit & Push".

Inspired by https://github.com/haydenull/logseq-plugin-git/issues/55 