### PR TITLE
Fixed: Add the option to modify the repo root relative path

### DIFF
--- a/src/helper/constants.ts
+++ b/src/helper/constants.ts
@@ -113,6 +113,14 @@ export const BUTTONS = [
 
 export const SETTINGS_SCHEMA: SettingSchemaDesc[] = [
   {
+    key: "customRepoRoot",
+    title: "Custom Repository Root Path",
+    type: "string",
+    default: "/",
+    description:
+      "Custom repository root, relative to the current graph root (can contain `..` path nodes). Defaults to /, which means the graph root.",
+  },
+  {
     key: "buttons",
     title: "Buttons",
     type: "enum",

--- a/src/helper/git.ts
+++ b/src/helper/git.ts
@@ -8,8 +8,16 @@ export const execGitCommand = async (args: string[]) : Promise<IGitResult> => {
 
   let res
   try {
-    const currentGitFolder = (await logseq.App.getCurrentGraph())?.path
-    const runArgs = currentGitFolder ? ['-C', currentGitFolder, ...args] : args
+    const currentGitFolder = (await logseq.App.getCurrentGraph())?.path;
+        const relCurrGitFolder = currentGitFolder
+          ? //path.resolve(
+            (((currentGitFolder as string) +
+              "/" +
+              logseq.settings?.customRepoRoot) as string)
+          : //)
+            (logseq.settings?.customRepoRoot as string);
+        const runArgs = relCurrGitFolder ? ["-C", relCurrGitFolder, ...args] : args;
+        //const runArgs = currentGitFolder ? ["-C", currentGitFolder, ...args] : args;
     _inProgress = logseq.Git.execCommand(runArgs)
     res = await _inProgress
   } finally {
@@ -147,7 +155,7 @@ export const push = async (showRes = true): Promise<IGitResult> => {
  * @returns The commit message.
  */
 export const commitMessage = () : string => {
-  
+
   let defaultMessage = "[logseq-plugin-git:commit]";
 
   switch (logseq.settings?.typeCommitMessage as string) {

--- a/src/helper/git.ts
+++ b/src/helper/git.ts
@@ -9,15 +9,15 @@ export const execGitCommand = async (args: string[]) : Promise<IGitResult> => {
   let res
   try {
     const currentGitFolder = (await logseq.App.getCurrentGraph())?.path;
-        const relCurrGitFolder = currentGitFolder
-          ? //path.resolve(
-            (((currentGitFolder as string) +
-              "/" +
-              logseq.settings?.customRepoRoot) as string)
-          : //)
-            (logseq.settings?.customRepoRoot as string);
-        const runArgs = relCurrGitFolder ? ["-C", relCurrGitFolder, ...args] : args;
-        //const runArgs = currentGitFolder ? ["-C", currentGitFolder, ...args] : args;
+    const relCurrGitFolder = currentGitFolder
+      ? //path.resolve(
+        (((currentGitFolder as string) +
+          "/" +
+          logseq.settings?.customRepoRoot) as string)
+      : //)
+        (logseq.settings?.customRepoRoot as string);
+    const runArgs = relCurrGitFolder ? ["-C", relCurrGitFolder, ...args] : args;
+    //const runArgs = currentGitFolder ? ["-C", currentGitFolder, ...args] : args;
     _inProgress = logseq.Git.execCommand(runArgs)
     res = await _inProgress
   } finally {
@@ -155,7 +155,7 @@ export const push = async (showRes = true): Promise<IGitResult> => {
  * @returns The commit message.
  */
 export const commitMessage = () : string => {
-
+  
   let defaultMessage = "[logseq-plugin-git:commit]";
 
   switch (logseq.settings?.typeCommitMessage as string) {


### PR DESCRIPTION
Fixed #73 by cleaning up any formatting/linting changes.

This should be ready to cleanly merge, if this seems okay as-is and doesn't need adapting with the path. 

Refer to #73 for more details.